### PR TITLE
Use custom css to fix external depenceny upload restriction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.egg-info*
 __pycache__
 db.sqlite3
+build/*
+tests/static/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include README.md
+recursive-include django_future_tasks/static *

--- a/django_future_tasks/admin.py
+++ b/django_future_tasks/admin.py
@@ -32,6 +32,9 @@ class PeriodicFutureTaskAdminForm(forms.ModelForm):
         model = PeriodicFutureTask
         exclude = ()
 
+    class Media:
+        css = {"all": ("django_future_tasks/cronfield.css",)}
+
 
 class FutureTaskInline(admin.TabularInline):
     verbose_name = "Corresponding single task"

--- a/django_future_tasks/static/django_future_tasks/cronfield.css
+++ b/django_future_tasks/static/django_future_tasks/cronfield.css
@@ -1,0 +1,21 @@
+.cc_wrapper .cc_element {
+	width: 160px;
+}
+
+.cc_wrapper .cc_element select {
+	margin-bottom: 2px;
+}
+
+.cc_wrapper .cc_element .button {
+	width: 76px;
+	margin: 2px;
+}
+
+.cc_wrapper .cc_element .fleft {
+	width: 75px;
+	margin: 2px;
+}
+
+.cc_wrapper .cc_element .fright {
+	margin: 2px;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ django>=3.2,<4
 # Cron
 croniter>=1.4.1,<1.5
 cron-descriptor>=1.4.0, <1.5
-git+https://github.com/galipnik/django-cronfield@updates-for-django-3.2
+django-cronfield>=0.2.0,<0.3

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     install_requires=[
         "croniter>=1.4.1,<1.5",
         "cron-descriptor>=1.4.0,<1.5",
-        "django-cronfield @ git+https://github.com/galipnik/django-cronfield@updates-for-django-3.2",
+        "django-cronfield>=0.2.0,<0.3",
     ],
     license="MIT License",
     description="A library to create periodic, cron-like tasks or single tasks with a specified execution/start time and schedule it to run in the future.",

--- a/tests/core/settings.py
+++ b/tests/core/settings.py
@@ -26,6 +26,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_future_tasks",
+    "cronfield",
     "testapp",
 ]
 
@@ -109,3 +110,7 @@ FUTURE_TASK_TYPES = (
     (FUTURE_TASK_TYPE_ERROR, "Task Error"),
     (FUTURE_TASK_TYPE_INTERRUPTION, "Task Interruption"),
 )
+
+STATIC_URL = "/static/"
+ROOT_URLCONF = "core.urls"
+STATIC_ROOT = os.path.join(BASE_DIR, "static")

--- a/tests/core/urls.py
+++ b/tests/core/urls.py
@@ -1,0 +1,4 @@
+from django.contrib import admin
+from django.urls import include, path
+
+urlpatterns = [path("admin/", admin.site.urls)]


### PR DESCRIPTION
This is required due to a restirction of PEP 440 and PEP 508 - https://github.com/pypi/warehouse/issues/7136#issuecomment-603529974

Log from https://github.com/anexia/django-future-tasks/actions/runs/7032213426/job/19135487570#step:7:20

```
Run twine upload dist/*
  twine upload dist/*
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.18/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib
    TWINE_REPOSITORY: ***
    TWINE_USERNAME: ***
    TWINE_PASSWORD: ***
    TWINE_NON_INTERACTIVE: yes
Uploading distributions to https://upload.***.org/legacy/
Uploading django_future_tasks-1.1.0-py3-none-any.whl
[2](https://github.com/anexia/django-future-tasks/actions/runs/7032213426/job/19135487570#step:7:2)5l
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/21.1 kB • --:-- • ?
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 21.1/21.1 kB • 00:00 • [3](https://github.com/anexia/django-future-tasks/actions/runs/7032213426/job/19135487570#step:7:3)8.6 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 21.1/21.1 kB • 00:00 • 38.6 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 21.1/21.1 kB • 00:00 • 38.6 MB/s
25hWARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: [4](https://github.com/anexia/django-future-tasks/actions/runs/7032213426/job/19135487570#step:7:4)00 Bad Request from [https://upload.***.org/legacy/](https://upload.%2A%2A%2A.org/legacy/)        
         Invalid value for requires_dist. Error: Can't have direct dependency:  
         'django-cronfield @                                                    
         git+https://github.com/galipnik/django-cronfield@updates-for-django-3.2
         '                                                                      
Error: Process completed with exit code 1.
```


It uses the latest release of `django-cronfield` and moves the css fixes as owerides in this repository.

We can revert this once https://github.com/knaperek/django-cronfield/pull/3 is merged and there is a new release.