### PR TITLE
Fixes compatibility between django 3.2 and 4.2 for next planned execution in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2]
+
+### Fixed
+
+- Fixes compatibility between django 3.2 and 4.2 for next planned execution in admin
+
+## [1.1.1]
+
+### Fixed
+
+- Use custom css to fix external depenceny upload restriction
+
 ## [1.1.0]
 
 ### Added
@@ -16,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial setup.
 
-[Unreleased]: https://github.com/anexia/django-future-tasks/compare/1.0.0...HEAD
+[Unreleased]: https://github.com/anexia/django-future-tasks/compare/1.1.2...HEAD
+[1.1.2]: https://github.com/anexia/django-future-tasks/releases/tag/1.1.2
+[1.1.1]: https://github.com/anexia/django-future-tasks/releases/tag/1.1.1
 [1.1.0]: https://github.com/anexia/django-future-tasks/releases/tag/1.1.0
 [1.0.0]: https://github.com/anexia/django-future-tasks/releases/tag/1.0.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="django-future-tasks",
-    version=os.getenv("PACKAGE_VERSION", "1.1.0").replace("refs/tags/", ""),
+    version=os.getenv("PACKAGE_VERSION", "1.1.2").replace("refs/tags/", ""),
     packages=find_packages(),
     include_package_data=True,
     install_requires=[

--- a/tests/core/settings.py
+++ b/tests/core/settings.py
@@ -91,7 +91,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "Europe/Vienna"
 
 USE_I18N = True
 


### PR DESCRIPTION
Adds a fix for the read only field `next_planned_execution` used in the list admin in order to be compatible with `pytz` and `zoneinfo` - https://docs.djangoproject.com/en/5.0/releases/4.0/#what-s-new-in-django-4-0