### PR TITLE
Log exceptions in handle_tick in process_future_tasks

### DIFF
--- a/django_future_tasks/management/commands/process_future_tasks.py
+++ b/django_future_tasks/management/commands/process_future_tasks.py
@@ -77,6 +77,7 @@ class Command(BaseCommand):
                         *sys.exc_info(), limit=None, chain=None
                     ),
                 }
+                logger.exception(exc)
             self.current_task_pk = None
             task.save()
 


### PR DESCRIPTION
Add exception logging to `process_future_tasks` command when processing a task. This allows collecting exceptions from future tasks in tools like Sentry.