### PR TITLE
Set ordering on tasks for processing

### DIFF
--- a/django_future_tasks/management/commands/process_future_tasks.py
+++ b/django_future_tasks/management/commands/process_future_tasks.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
     def tasks_for_processing():
         return FutureTask.objects.filter(
             eta__lte=timezone.now(), status=FutureTask.FUTURE_TASK_STATUS_OPEN
-        )
+        ).order_by('eta')
 
     @staticmethod
     def _convert_exception_args(args):


### PR DESCRIPTION
If several tasks are available in the queue, the command should take the tasks with the lowest ETA.