### PR TITLE
Fix infinite loop in populate_periodic_future_tasks on IntegrityError

### DIFF
--- a/django_future_tasks/management/commands/populate_periodic_future_tasks.py
+++ b/django_future_tasks/management/commands/populate_periodic_future_tasks.py
@@ -5,6 +5,7 @@ import time
 from croniter import croniter_range
 from django import db
 from django.core.management.base import BaseCommand
+from django.db import IntegrityError
 from django.utils import timezone
 
 from django_future_tasks.models import FutureTask, PeriodicFutureTask
@@ -62,15 +63,21 @@ class Command(BaseCommand):
 
                 dt_format = "%Y-%m-%d %H:%M:%S%z"
                 task_id = f"{p_task.periodic_task_id} ({dt.strftime(dt_format)})"
-                FutureTask.objects.create(
-                    task_id=task_id,
-                    eta=dt,
-                    data=p_task.data,
-                    type=p_task.type,
-                    status=FutureTask.FUTURE_TASK_STATUS_OPEN,
-                    periodic_parent_task_id=p_task.pk,
-                )
-                logger.info(f"FutureTask {task_id} created")
+                try:
+                    FutureTask.objects.create(
+                        task_id=task_id,
+                        eta=dt,
+                        data=p_task.data,
+                        type=p_task.type,
+                        status=FutureTask.FUTURE_TASK_STATUS_OPEN,
+                        periodic_parent_task_id=p_task.pk,
+                    )
+                    logger.info(f"FutureTask {task_id} created")
+                except IntegrityError as exc:
+                    logger.warning(
+                        f"Database constraint violation creating FutureTask {task_id}: {exc}. Skipping duplicate task.",
+                    )
+                    continue
 
             p_task.last_task_creation = now
             p_task.save()

--- a/tests/testapp/tests/test_periodic_future_tasks.py
+++ b/tests/testapp/tests/test_periodic_future_tasks.py
@@ -1,6 +1,7 @@
 import time
 from datetime import timedelta
 
+import time_machine
 from django.core.exceptions import ValidationError
 from django.test import TransactionTestCase
 from django.utils import timezone
@@ -137,3 +138,45 @@ class TestPeriodicFutureTasks(PopulatePeriodicTaskCommandMixin, TransactionTestC
         p_task.max_number_of_executions = 42
         p_task.end_time = timezone.now()
         self.assertRaises(ValidationError, p_task.save)
+
+
+class TestSkipPeriodicFutureTasks(TransactionTestCase):
+    """Test class for IntegrityError handling without background command threading"""
+
+    @time_machine.travel("2025-01-01 12:00:00+0000", tick=False)
+    def test_populate_skips_duplicate_task_id_integrity_error(self):
+        # Create periodic task that will generate tasks
+        PeriodicFutureTask.objects.create(
+            periodic_task_id="Fetch Data",
+            type=settings.FUTURE_TASK_TYPE_ONE,
+            cron_string="0 * * * *",
+            last_task_creation=timezone.now() - timedelta(hours=2),
+        )
+
+        # Create conflicting task that will cause IntegrityError
+        conflicting_task_id = "Fetch Data (2025-01-01 12:00:00+0000)"
+        FutureTask.objects.create(
+            task_id=conflicting_task_id,
+            eta=timezone.now(),
+            type=settings.FUTURE_TASK_TYPE_ONE,
+        )
+
+        initial_task_count = FutureTask.objects.count()
+
+        # Run populate command and verify IntegrityError handling
+        from django_future_tasks.management.commands.populate_periodic_future_tasks import (
+            Command,
+        )
+
+        command = Command()
+        command.tick = 1
+
+        with self.assertLogs(
+            "populate_periodic_future_tasks",
+            level="WARNING",
+        ) as log_capture:
+            command.handle_tick()
+
+        # Verify warning was logged and task count unchanged
+        self.assertIn("Skipping duplicate task", log_capture.records[0].getMessage())
+        self.assertEqual(FutureTask.objects.count(), initial_task_count)


### PR DESCRIPTION
Fix infinite loop in populate_periodic_future_tasks on duplicate task_id

The populate_periodic_future_tasks command would get stuck in an infinite loop when encountering database constraint violations (IntegrityError) due to duplicate task_id values.

Solution:
  - Added try-catch block around FutureTask creation in populate_periodic_future_tasks
  - On IntegrityError, log a warning message and continue to skip the duplicate task instead of crashing
  - This allows the command to process remaining tasks normally
